### PR TITLE
Add option to enable/disable sending of email addresses to Sentry

### DIFF
--- a/js/src/admin/index.js
+++ b/js/src/admin/index.js
@@ -36,5 +36,10 @@ app.initializers.add('fof/sentry', () => {
             type: 'number',
             min: 0,
             max: 100,
+        })
+        .registerSetting({
+            label: app.translator.trans('fof-sentry.admin.settings.send_user_emails_label'),
+            setting: 'fof-sentry.send_emails_with_sentry_reports',
+            type: 'boolean',
         });
 });

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -6,6 +6,8 @@ window.Sentry = Sentry;
 window.Sentry.Integrations.CaptureConsole = CaptureConsole;
 window.Sentry.TracingIntegrations = TracingIntegrations;
 
+// All Sentry initialisation happens in `src/Content/SentryJavaScript.php`
+
 window.Sentry.getUserData = (nameAttr = 'username') => {
     /** @type {Sentry.User} */
     let userData = {};

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -7,3 +7,4 @@ fof-sentry:
       javascript_console_label: Capture JavaScript Console
       javascript_trace_sample_rate: Front-end Performance Monitoring Rate (0 - 100)
       monitor_performance_label: Back-end Performance Monitoring Rate (0 - 100)
+      send_user_emails_label: Send user email addresses with Sentry reports?


### PR DESCRIPTION
This PR adds an option to the admin page to enable/disable sending of email addresses to Sentry.

Previously, by default, this extension would automatically send email addresses to Sentry as part of a user's information, along with IP, username, and user ID. While all of these are also examples of PII (personally identifiable information), the reasoning behind these being sent to Sentry is justified.

Emails can always be looked up in the Flarum database by user ID or username, so the sending of email addresses is not necessary. Nevertheless, the option is still there for people to select.

**Sending of email addresses will be disabled by default.**