### PR TITLE
Feat/sentry environment

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "flarum/core": "^1.2.0",
+        "flarum/core": "^1.3.1",
         "sentry/sdk": "^3.1.0"
     },
     "authors": [

--- a/extend.php
+++ b/extend.php
@@ -13,6 +13,7 @@ namespace FoF\Sentry;
 
 use Flarum\Extend as Flarum;
 use Flarum\Frontend\RecompileFrontendAssets;
+use Flarum\Http\UrlGenerator;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\Event\Saved;
 use FoF\Sentry\Middleware\HandleErrorsWithSentry;
@@ -58,5 +59,6 @@ return [
         }),
 
     (new Flarum\Settings())
-        ->default('fof-sentry.monitor_performance', 0),
+        ->default('fof-sentry.monitor_performance', 0)
+        ->default('fof-sentry.environment', resolve(UrlGenerator::class)->to('forum')->base()),
 ];

--- a/extend.php
+++ b/extend.php
@@ -13,7 +13,6 @@ namespace FoF\Sentry;
 
 use Flarum\Extend as Flarum;
 use Flarum\Frontend\RecompileFrontendAssets;
-use Flarum\Http\UrlGenerator;
 use Flarum\Locale\LocaleManager;
 use Flarum\Settings\Event\Saved;
 use FoF\Sentry\Middleware\HandleErrorsWithSentry;
@@ -59,6 +58,5 @@ return [
         }),
 
     (new Flarum\Settings())
-        ->default('fof-sentry.monitor_performance', 0)
-        ->default('fof-sentry.environment', resolve(UrlGenerator::class)->to('forum')->base()),
+        ->default('fof-sentry.monitor_performance', 0),
 ];

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -9,6 +9,11 @@ app.initializers.add('fof/sentry', () => {
       type: 'url',
     })
     .registerSetting({
+      label: app.translator.trans('fof-sentry.admin.settings.environment_label'),
+      setting: 'fof-sentry.environment',
+      type: 'string',
+    })
+    .registerSetting({
       label: app.translator.trans('fof-sentry.admin.settings.user_feedback_label'),
       setting: 'fof-sentry.user_feedback',
       type: 'boolean',

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -2,6 +2,7 @@ fof-sentry:
   admin:
     settings:
       dsn_label: Sentry DSN
+      environment_label: Sentry Environment
       user_feedback_label: User Feedback
       javascript_label: Report JavaScript Errors
       javascript_console_label: Capture JavaScript Console

--- a/src/Content/SentryJavaScript.php
+++ b/src/Content/SentryJavaScript.php
@@ -12,6 +12,7 @@
 namespace FoF\Sentry\Content;
 
 use Flarum\Frontend\Document;
+use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 
 class SentryJavaScript
@@ -21,9 +22,15 @@ class SentryJavaScript
      */
     private $settings;
 
-    public function __construct(SettingsRepositoryInterface $settings)
+    /**
+     * @var UrlGenerator
+     */
+    private $url;
+
+    public function __construct(SettingsRepositoryInterface $settings, UrlGenerator $url)
     {
         $this->settings = $settings;
+        $this->url = $url;
     }
 
     public function __invoke(Document $document)
@@ -35,7 +42,7 @@ class SentryJavaScript
         }
 
         $dsn = $this->settings->get('fof-sentry.dsn');
-        $environment = $this->settings->get('fof-sentry.environment');
+        $environment = empty($this->settings->get('fof-sentry.environment')) ? str_replace(['https://', 'http://'], '', $this->url->to('forum')->base()) : $this->settings->get('fof-sentry.environment');
         $showFeedback = (bool) (int) $this->settings->get('fof-sentry.user_feedback');
         $captureConsole = (bool) (int) $this->settings->get('fof-sentry.javascript.console');
 

--- a/src/Content/SentryJavaScript.php
+++ b/src/Content/SentryJavaScript.php
@@ -35,6 +35,7 @@ class SentryJavaScript
         }
 
         $dsn = $this->settings->get('fof-sentry.dsn');
+        $environment = $this->settings->get('fof-sentry.environment');
         $showFeedback = (bool) (int) $this->settings->get('fof-sentry.user_feedback');
         $captureConsole = (bool) (int) $this->settings->get('fof-sentry.javascript.console');
 
@@ -56,6 +57,7 @@ class SentryJavaScript
                     if (window.Sentry) {
                         Sentry.init({
                             dsn: '$dsn',
+                            environment: '$environment',
                             beforeSend: function(event) {
                                 event.logger = 'javascript';
 

--- a/src/SentryServiceProvider.php
+++ b/src/SentryServiceProvider.php
@@ -48,6 +48,7 @@ class SentryServiceProvider extends AbstractServiceProvider
             /** @var SettingsRepositoryInterface $settings */
             $settings = $container->make(SettingsRepositoryInterface::class);
             $dsn = $settings->get('fof-sentry.dsn');
+            $environment = $settings->get('fof-sentry.environment');
             $performanceMonitoring = (int) $settings->get('fof-sentry.monitor_performance');
 
             /** @var Paths $paths */
@@ -55,14 +56,11 @@ class SentryServiceProvider extends AbstractServiceProvider
 
             $tracesSampleRate = $performanceMonitoring > 0 ? round($performanceMonitoring / 100, 2) : 0;
 
-            /** @var Config $config */
-            $config = $container->make(Config::class);
-
             init([
                 'dsn'                   => $dsn,
                 'in_app_include'        => [$paths->base],
                 'traces_sample_rate'    => $tracesSampleRate,
-                'environment'           => str_replace(['https://', 'http://'], '', Arr::get($config, 'url')),
+                'environment'           => $environment,
                 'release'               => Application::VERSION,
             ]);
 

--- a/src/SentryServiceProvider.php
+++ b/src/SentryServiceProvider.php
@@ -20,6 +20,7 @@ use Flarum\Foundation\ErrorHandling\ViewFormatter;
 use Flarum\Foundation\Paths;
 use Flarum\Frontend\Assets;
 use Flarum\Frontend\Compiler\Source\SourceCollector;
+use Flarum\Http\UrlGenerator;
 use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\Sentry\Contracts\Measure;
 use FoF\Sentry\Formatters\SentryFormatter;
@@ -47,8 +48,10 @@ class SentryServiceProvider extends AbstractServiceProvider
         $this->container->singleton(HubInterface::class, function ($container) {
             /** @var SettingsRepositoryInterface $settings */
             $settings = $container->make(SettingsRepositoryInterface::class);
+            /** @var UrlGenerator $urlGenerator */
+            $url = $container->make(UrlGenerator::class);
             $dsn = $settings->get('fof-sentry.dsn');
-            $environment = $settings->get('fof-sentry.environment');
+            $environment = empty($settings->get('fof-sentry.environment')) ? str_replace(['https://', 'http://'], '', $url->to('forum')->base()) : $settings->get('fof-sentry.environment');
             $performanceMonitoring = (int) $settings->get('fof-sentry.monitor_performance');
 
             /** @var Paths $paths */


### PR DESCRIPTION
**Adds [Sentry Environments](https://docs.sentry.io/product/sentry-basics/environments/) support**

**Changes proposed in this pull request:**
This PR adds support for setting a custom sentry environment while unifying the default to the base URL.

**Screenshot**
Setting in the admin interface with default:
![Admin Setting](https://user-images.githubusercontent.com/9606082/181256051-a282299f-1eb1-4e51-99e0-75bf390638e0.png)

Environment set in request to sentry instance:
![Default Env in Request](https://user-images.githubusercontent.com/9606082/181256482-68b2bf2f-dbfc-42ca-b8ce-4ff55aa48845.png)

Settings in admin interface with custom environment:
![Admin Setting](https://user-images.githubusercontent.com/9606082/181257525-b9aad441-6ed3-48a3-8586-1f66e2da6f28.png)

Custom Environment in request to sentry instance:
![Custom Env in Request](https://user-images.githubusercontent.com/9606082/181257729-6e051266-7542-4918-a507-63041489287a.png)


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [X] Backend changes: tested on a local Flarum installation.


